### PR TITLE
Drop TemplateLoader in favor of OPTCGVision

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        
+        {
+            "name": "Python Debugger: Current File",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${file}",
+            "cwd": "${workspaceRoot}",
+            "console": "integratedTerminal",
+            "env": {"PYTHONPATH": "${workspaceRoot}"}
+        }
+    ]
+}

--- a/rl/env.py
+++ b/rl/env.py
@@ -68,3 +68,24 @@ class OPTCGEnv(gym.Env if gym is not None else object):
         if self._steps >= self._max_steps:
             truncated = True
         return obs, reward, terminated, truncated, {}
+
+
+def main(num_steps: int = 10) -> None:
+    """Run a short random rollout for quick manual testing."""
+    env = OPTCGEnv(max_steps=num_steps)
+    obs, _ = env.reset()
+    print("reset ->", obs)
+    for t in range(num_steps):
+        if gym is not None and env.action_space is not None:
+            action = env.action_space.sample()
+        else:
+            action = t % 3  # deterministic fallback
+        obs, reward, terminated, truncated, _ = env.step(action)
+        print(f"step {t}: a={action} r={reward} term={terminated} trunc={truncated}")
+        if terminated or truncated:
+            break
+    print("final obs ->", obs)
+
+
+if __name__ == "__main__":
+    main()

--- a/rl/env.py
+++ b/rl/env.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 from __future__ import annotations
 
 import time

--- a/rl/env.py
+++ b/rl/env.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import time
+from typing import Any, Tuple
+
+try:
+    import gym
+    from gym import spaces
+except Exception:  # pragma: no cover - gym is optional for linting/test envs
+    gym = None
+    spaces = None
+
+from utils.gui import gui_macros as MACROS
+from utils.gui import gui_automation_starter as GUI
+from utils.vision import finder
+
+
+class OPTCGEnv(gym.Env if gym is not None else object):
+    """Minimal OPTCGSim environment following the Gym API."""
+
+    def __init__(self, max_steps: int = 50, step_delay: float = 0.5) -> None:
+        super().__init__()
+        # Instantiate the vision helper used for observation gathering
+        self._vision = finder.OPTCGVision()
+        self._max_steps = max_steps
+        self._delay = step_delay
+        self._steps = 0
+
+        if spaces is not None:
+            self.action_space = spaces.Discrete(3)
+            self.observation_space = spaces.Dict(
+                {
+                    "can_attack": spaces.Discrete(2),
+                    "can_resolve": spaces.Discrete(2),
+                    "can_end_turn": spaces.Discrete(2),
+                }
+            )
+        else:  # pragma: no cover
+            self.action_space = None  # type: ignore
+            self.observation_space = None  # type: ignore
+
+    # ------------------------------------------------------------------
+    # Core API
+    # ------------------------------------------------------------------
+    def reset(self, *, seed: int | None = None, options: dict[str, Any] | None = None) -> Tuple[dict[str, Any], dict[str, Any]]:
+        if gym is not None:
+            super().reset(seed=seed)
+        self._steps = 0
+        obs = self._vision.scan()
+        return obs, {}
+
+    def step(self, action: int) -> Tuple[dict[str, Any], float, bool, bool, dict[str, Any]]:
+        """Execute *action* and return the new observation."""
+        terminated = False
+        truncated = False
+        reward = 0.0
+
+        if action == 0:  # Leader attacks leader
+            MACROS.attack(1, 0, 2, 0)
+        elif action == 1:  # End turn
+            GUI.click_end_turn()
+        time.sleep(self._delay)
+
+        obs = self._vision.scan()
+        if obs.get("can_resolve"):
+            reward += 1.0
+        self._steps += 1
+        if self._steps >= self._max_steps:
+            truncated = True
+        return obs, reward, terminated, truncated, {}

--- a/tests/test_find_card.py
+++ b/tests/test_find_card.py
@@ -23,7 +23,7 @@ def test_find_card():
     """
     Try up to 5 consecutive frames to catch the card; fail if none are found.
     """
-    finder = TEMPLATES.TemplateLoader()
+    finder = TEMPLATES.OPTCGVision()
     attempts, hits = 5, []
     for _ in range(attempts):
         hits = finder.find("OP10-001")

--- a/utils/gui/gui_automation_starter.py
+++ b/utils/gui/gui_automation_starter.py
@@ -108,6 +108,7 @@ def click_action0() -> None:
 def click_end_turn() -> None:
     """Click End Turn with confirmation by clicking Action 0 twice."""
     click_action0()
+    time.sleep(CLICK_DELAY)
     click_action0()
 
 

--- a/utils/vision/capture.py
+++ b/utils/vision/capture.py
@@ -1,4 +1,4 @@
-# utils/capture.py
+#!/usr/bin/env python
 """OPTCG‑Sim computer‑vision helpers
 ====================================
 Capture frames directly from the **OPTCGSim.exe** window—even when other

--- a/utils/vision/finder.py
+++ b/utils/vision/finder.py
@@ -1,4 +1,4 @@
-# utils/vision/finder.py
+#!/usr/bin/env python
 """Template management + convenience find() wrapper for OPTCG-Sim automation.
 
 Changes in this version
@@ -17,7 +17,7 @@ from typing import Any, Dict, List, Optional, Tuple
 import cv2
 import numpy as np
 
-from capture import OPTCGVisionHelper
+from utils.vision.capture import OPTCGVisionHelper
 
 # ---------------------------------------------------------------------------
 # File-system layout (adjust if your repo moves)

--- a/utils/vision/finder.py
+++ b/utils/vision/finder.py
@@ -3,7 +3,7 @@
 
 Changes in this version
 -----------------------
-* All logic lives in **TemplateLoader** – easy to instantiate in tests.
+* All logic lives in **OPTCGVision** – easy to instantiate in tests.
 * A module-level singleton :data:`loader` preserves the old global behaviour.
 * Old helpers (:pydata:`vision`, :pyfunc:`find`, :pyfunc:`load_card`) now
   delegate to that singleton, so no refactor is required elsewhere.
@@ -278,6 +278,24 @@ class OPTCGVision:
             obs["initial_hand_p2"] = initial_hand_p2
 
         return obs
+
+
+# ---------------------------------------------------------------------------
+# Module-level convenience helpers -----------------------------------------
+# ---------------------------------------------------------------------------
+
+# Global singleton for convenience APIs
+loader = OPTCGVision()
+
+
+def find(key: str, frame: np.ndarray | None = None, is_card: bool = False) -> List[Match]:
+    """Module-level helper that delegates to :data:`loader`."""
+    return loader.find(key, frame=frame, is_card=is_card)
+
+
+def load_card(code: str) -> np.ndarray:
+    """Return the template image for *code* using the module loader."""
+    return loader.resolve(code)
 
 
 def test_find(key: str):


### PR DESCRIPTION
## Summary
- initialize `OPTCGEnv` using `OPTCGVision`
- update vision module docs and remove the `TemplateLoader` alias
- update integration test to construct `OPTCGVision`

## Testing
- `pip install -r requirements.txt`
- `pip install opencv-python numpy psutil mss`
- `pytest -q` *(fails: KeyError: 'DISPLAY', ModuleNotFoundError: 'capture')*

------
https://chatgpt.com/codex/tasks/task_e_6843688c75dc833095de69289e305853