### PR TITLE
Implement dynamic hand scanning

### DIFF
--- a/utils/vision/finder.py
+++ b/utils/vision/finder.py
@@ -146,9 +146,10 @@ class OPTCGVision:
             key_lc = key.lower()
             if key in CARDS:
                 board_img = img if key in UNCROPPED_CARDS else _crop_card_border(img)
-                hand_img = _left_edge(img)
+                if key not in UNCROPPED_CARDS:
+                    hand_img = _left_edge(img)
+                    self._hand_templates[key_lc] = hand_img
                 self._board_templates[key_lc] = board_img
-                self._hand_templates[key_lc] = hand_img
                 self._static[key_lc] = board_img
             else:
                 self._static[key_lc] = img
@@ -214,6 +215,8 @@ class OPTCGVision:
     ) -> str:
         """Return the first card template that matches in `roi`, else None."""
         for name in CARDS:  # simple linear scan
+            if hand and name in UNCROPPED_CARDS:
+                continue
             if self.find(name, frame=roi, is_card=True, rotated=rotated, hand=hand):
                 return name
         return ""
@@ -273,6 +276,8 @@ class OPTCGVision:
             roi = frame[y0:y1, x0:x1]
             total = 0
             for name in CARDS:
+                if name in UNCROPPED_CARDS:
+                    continue
                 total += len(self.find(name, frame=roi, is_card=True, hand=True))
             return total
 

--- a/utils/vision/finder.py
+++ b/utils/vision/finder.py
@@ -26,7 +26,7 @@ from utils.vision.capture import OPTCGVisionHelper
 # Portion of the card image to trim from each border before matching
 BORDER_PCT = 0.35
 # Portion of the card image to keep from the left when loading hand templates
-HAND_LEFT_PCT = 0.10
+HAND_LEFT_PCT = 0.20
 
 # Scale to convert template size to in-game card size
 CARD_SCALE = 99 / 120
@@ -256,10 +256,10 @@ class OPTCGVision:
         can_draw = bool(buttons.get("dont_draw_any"))
 
         # 2. Constants -------------------------------------------------------
-        SLOT_WIDTH_PCT = 0.10
+        SLOT_WIDTH_PCT = 0.05
         SLOTS = 5
         HAND_TOTAL_WIDTH_PCT = 0.20
-        HAND_SCAN_X0 = 0.0
+        HAND_SCAN_X0 = 0.05
         HAND_SCAN_X1 = 0.30
         CHOICE_SHIFT_PCT = 0.05
         BOARD_WIDTH_PCT, BOARD_STEP_PCT = 0.10, 0.06

--- a/utils/vision/finder.py
+++ b/utils/vision/finder.py
@@ -26,7 +26,7 @@ from utils.vision.capture import OPTCGVisionHelper
 # Portion of the card image to trim from each border before matching
 BORDER_PCT = 0.35
 # Portion of the card image to keep from the left when loading hand templates
-HAND_LEFT_PCT = 0.20
+HAND_LEFT_PCT = 0.15
 
 # Scale to convert template size to in-game card size
 CARD_SCALE = 99 / 120
@@ -201,7 +201,7 @@ class OPTCGVision:
             frame = self.grab()
             if frame is None:
                 return []
-        threshold = FIND_THRESHOLD
+        threshold = 0.9 if hand else FIND_THRESHOLD
         scales = CARD_SCALE if is_card else 1.0
         if rotated:
             template = cv2.rotate(template, cv2.ROTATE_90_CLOCKWISE)
@@ -256,12 +256,12 @@ class OPTCGVision:
         can_draw = bool(buttons.get("dont_draw_any"))
 
         # 2. Constants -------------------------------------------------------
-        SLOT_WIDTH_PCT = 0.05
+        SLOT_WIDTH_PCT = 0.03
         SLOTS = 5
-        HAND_TOTAL_WIDTH_PCT = 0.20
+        HAND_TOTAL_WIDTH_PCT = 0.2
         HAND_SCAN_X0 = 0.0
         HAND_SCAN_X1 = 0.25
-        HAND_SLOT_START_PCT = 0.05
+        HAND_SLOT_START_PCT = 0.02
         CHOICE_SHIFT_PCT = 0.05
         BOARD_WIDTH_PCT, BOARD_STEP_PCT = 0.10, 0.06
         BOARD_P1_START_X, BOARD_P1_Y = 0.40, 0.6
@@ -291,6 +291,8 @@ class OPTCGVision:
                 x0 = int((HAND_SLOT_START_PCT + shift_pct * i) * w)
                 x1 = int(x0 + SLOT_WIDTH_PCT * w)
                 roi = frame[y0:y1, x0:x1]
+                # cv2.imshow('', roi)
+                # cv2.waitKey(0)
                 cards.append(self._detect_card_in_roi(roi, hand=True))
             return cards
 

--- a/utils/vision/finder.py
+++ b/utils/vision/finder.py
@@ -259,8 +259,9 @@ class OPTCGVision:
         SLOT_WIDTH_PCT = 0.05
         SLOTS = 5
         HAND_TOTAL_WIDTH_PCT = 0.20
-        HAND_SCAN_X0 = 0.05
-        HAND_SCAN_X1 = 0.30
+        HAND_SCAN_X0 = 0.0
+        HAND_SCAN_X1 = 0.25
+        HAND_SLOT_START_PCT = 0.05
         CHOICE_SHIFT_PCT = 0.05
         BOARD_WIDTH_PCT, BOARD_STEP_PCT = 0.10, 0.06
         BOARD_P1_START_X, BOARD_P1_Y = 0.40, 0.6
@@ -287,7 +288,7 @@ class OPTCGVision:
                 return cards
             shift_pct = HAND_TOTAL_WIDTH_PCT / max(hand_size - 1, 1)
             for i in range(hand_size):
-                x0 = int(shift_pct * i * w)
+                x0 = int((HAND_SLOT_START_PCT + shift_pct * i) * w)
                 x1 = int(x0 + SLOT_WIDTH_PCT * w)
                 roi = frame[y0:y1, x0:x1]
                 cards.append(self._detect_card_in_roi(roi, hand=True))


### PR DESCRIPTION
## Summary
- store board and hand templates for cards
- add dynamic scanning logic for player hands
- track `hand_p1` and `hand_p2` instead of `initial_hand`/`latest_card`
- expose a `hand` flag on `find` and `resolve`

## Testing
- `python -m py_compile utils/vision/finder.py`

------
https://chatgpt.com/codex/tasks/task_e_684a0f30e3c08330ba1a45d4ed8d0718