### PR TITLE
Add deploy_card macro

### DIFF
--- a/tests/test_deploy_card.py
+++ b/tests/test_deploy_card.py
@@ -1,0 +1,29 @@
+"""
+Integration Test #8 – Deploying a hand card using the macro.
+
+Sequence:
+1. Player 1 deploys hand card #0 (Action 1 to confirm)
+2. End Turn
+3. Player 2 deploys hand card #0
+4. End Turn
+"""
+
+import time
+import importlib
+
+GUI    = importlib.import_module("utils.gui.gui_automation_starter")
+MACROS = importlib.import_module("utils.gui.gui_macros")
+
+
+def test_deploy_card_real():
+    GUI.pag.FAILSAFE = True
+
+    time.sleep(2)
+    MACROS.deploy_card(acting_player=1, hand_card_index=0, hand_size=6)
+    time.sleep(0.5)
+    GUI.click_end_turn(); time.sleep(0.7)
+
+    MACROS.deploy_card(acting_player=2, hand_card_index=0, hand_size=7)
+    time.sleep(0.5)
+    GUI.click_end_turn(); time.sleep(0.7)
+    # No assertion required; any exception would fail the test.

--- a/utils/gui/gui_macros.py
+++ b/utils/gui/gui_macros.py
@@ -12,6 +12,7 @@ Public API
   multi‑target card actions.
 * attack()         – convenience wrapper for the common "Action 1 = Attack"
   pattern that lets you specify any acting *and* target card.
+* deploy_card()    – select a card from hand and confirm with Action 1.
 * attach_don()     – attach one or more DON!! cards to a specified card on
   the active player's board.
 
@@ -97,6 +98,37 @@ def attack(
     )
 
 
+def deploy_card(
+    acting_player: int,
+    hand_card_index: int,
+    hand_size: int,
+) -> None:
+    """Deploy a card from the acting player's hand and confirm.
+
+    Parameters
+    ----------
+    acting_player : int
+        1 for Player 1, 2 for Player 2.
+    hand_card_index : int
+        Index of the card to deploy (0 = left‑most).
+    hand_size : int
+        Total number of cards currently in that hand.
+    """
+    # --- Validate ----------------------------------------------------
+    if acting_player not in (1, 2):
+        raise ValueError("acting_player must be 1 or 2")
+    if hand_size < 1:
+        raise ValueError("hand_size must be at least 1")
+    if not 0 <= hand_card_index < hand_size:
+        raise ValueError("hand_card_index must be within hand_size")
+
+    # --- Select card from hand --------------------------------------
+    _click_hand_card(acting_player, hand_card_index, hand_size)
+
+    # --- Confirm with Action 1 --------------------------------------
+    GUI.click_action1()
+
+
 def attach_don(
     acting_player: int,
     card_index: int,
@@ -175,3 +207,10 @@ def _click_board_card(player: int, idx: int) -> None:
             GUI.click_p2_leader()
         else:
             GUI.click_p2_card(idx - 1)
+
+
+def _click_hand_card(player: int, idx: int, hand_size: int) -> None:
+    if player == 1:
+        GUI.click_p1_hand(card_index=idx, hand_size=hand_size)
+    else:
+        GUI.click_p2_hand(card_index=idx, hand_size=hand_size)

--- a/utils/gui/gui_macros.py
+++ b/utils/gui/gui_macros.py
@@ -166,7 +166,6 @@ def attach_don(
     click_don = GUI.click_p1_don if acting_player == 1 else GUI.click_p2_don
 
     # --- Compute DON indices to click -------------------------------
-    start_idx = total_don - attachable_don  # first attachable DON index
     first_to_click = total_don - num_to_attach
     don_indices = range(first_to_click, total_don)  # inclusive‑exclusive
 


### PR DESCRIPTION
## Summary
- expand public GUI macro API with `deploy_card()` for playing cards from hand
- implement helper `_click_hand_card` to reuse hand card selection logic

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cc8803e608330866f65941294df04