### PR TITLE
Add attack power observation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ venv/
 __pycache__/
 utils/vision/templates/cards (all)/
 utils/vision/templates/labels/
+logs/

--- a/utils/vision/capture.py
+++ b/utils/vision/capture.py
@@ -227,7 +227,7 @@ class OPTCGVisionHelper:
         )
 
         # --- 5. OCR -----------------------------------------------------------
-        config = "--psm 6 --oem 1 -c tessedit_char_whitelist=GlOIS0123456789"
+        config = "--psm 6 --oem 1 -c tessedit_char_whitelist=GlOIS0123456789+"
         text: str = pytesseract.image_to_string(mask_clean, config=config).strip()
 
         # -- 6. Replace letters with numbers

--- a/utils/vision/finder.py
+++ b/utils/vision/finder.py
@@ -458,7 +458,7 @@ class OPTCGVision:
             text = OPTCGVisionHelper.detect_number(frame)
             if text:
                 try:
-                    nums = [int(t) for t in text.replace(',', ' ').split()]
+                    nums = [int(t) for t in text.replace(',', ' ').split() if '+' not in t]
                     if len(nums) >= 2:
                         attack_powers = nums[:2]
                 except ValueError:

--- a/utils/vision/finder.py
+++ b/utils/vision/finder.py
@@ -145,6 +145,7 @@ class OPTCGObs:
     num_active_don_p2: int
     num_life_p1: int
     num_life_p2: int
+    attack_powers: List[int]
 
 
 class OPTCGVision:
@@ -451,7 +452,19 @@ class OPTCGVision:
             choice_y0, choice_y1 = int(0.65 * h), int(0.85 * h)
             choice_cards = scan_choices(choice_y0, choice_y1)
 
-        # 6. Pack observations ----------------------------------------------
+        # 6. Attack power numbers -----------------------------------------
+        attack_powers: List[int] = [-1, -1]
+        if buttons.get("resolve_attack"):
+            text = OPTCGVisionHelper.detect_number(frame)
+            if text:
+                try:
+                    nums = [int(t) for t in text.replace(',', ' ').split()]
+                    if len(nums) >= 2:
+                        attack_powers = nums[:2]
+                except ValueError:
+                    pass
+
+        # 7. Pack observations ----------------------------------------------
         obs = OPTCGObs(
             can_attack = bool(buttons.get("attack")),
             can_blocker = bool(buttons.get("no_blocker")),
@@ -474,6 +487,7 @@ class OPTCGVision:
             num_life_p1 = num_life_p1,
             num_life_p2 = num_life_p2,
             choice_cards = choice_cards,
+            attack_powers = attack_powers,
         )
 
         return obs


### PR DESCRIPTION
## Summary
- track attack power numbers when resolving an attack
- store these numbers on `OPTCGObs`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6885379fd2688330bcae0b980cdaf4d7