### PR TITLE
Add attack power values in OPTCGEnv observations

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from rl.agent import PPOAgent
-from rl.env import OPTCGEnv
+from rl.env import OPTCGEnvBase
 
-__all__ = ["PPOAgent", "OPTCGEnv"]
+__all__ = ["PPOAgent", "OPTCGEnvBase"]
 

--- a/rl/__init__.py
+++ b/rl/__init__.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from .agent import DQNAgent, DQNConfig
-from .env import OPTCGEnv
+from .env import OPTCGEnvBase
 
-__all__ = ["DQNAgent", "DQNConfig", "OPTCGEnv"]
+__all__ = ["DQNAgent", "DQNConfig", "OPTCGEnvBase"]
 

--- a/rl/agent.py
+++ b/rl/agent.py
@@ -4,55 +4,17 @@ from dataclasses import asdict
 from typing import Any
 
 from stable_baselines3.common.callbacks import BaseCallback
-from stable_baselines3.common.vec_env import VecMonitor
 from stable_baselines3.common.env_checker import check_env
 from sb3_contrib import MaskablePPO
-from sb3_contrib.common.maskable.policies import MaskableActorCriticPolicy
 from sb3_contrib.common.wrappers import ActionMasker
-import gymnasium as gym
-from pettingzoo.utils import conversions
-import supersuit as ss
 
-from pettingzoo.utils import BaseWrapper
-from env import OPTCGEnv, OPTCGPlayerObs
-
-
-class SB3ActionMaskWrapper(BaseWrapper, gym.Env):
-    """Wrapper to adapt PettingZoo AEC environments for SB3 with action masking."""
-
-    def reset(self, seed: int | None = None, options: dict[str, Any] | None = None):
-        super().reset(seed=seed, options=options)
-        self.observation_space = super().observation_space(self.possible_agents[0])
-        self.action_space = super().action_space(self.possible_agents[0])
-        return self.observe(self.agent_selection), {}
-
-    def step(self, action: int):
-        current_agent = self.agent_selection
-        super().step(action)
-        next_agent = self.agent_selection
-        return (
-            self.observe(next_agent),
-            self.rewards[current_agent],
-            self.terminations[current_agent],
-            self.truncations[current_agent],
-            self.infos[current_agent],
-        )
-
-    def observe(self, agent: str):
-        obs = super().observe(agent)
-        if isinstance(obs, OPTCGPlayerObs):
-            return asdict(obs)
-        return obs
-
-    def action_mask(self):
-        return self.env.action_mask(self.env.agent_selection)
+from env import OPTCGPlayerObs, OPTCGEnv
 
 
 class PPOAgent:
     """Minimal PPO agent using Stable-Baselines3."""
 
     def __init__(self, env: OPTCGEnv, *, verbose: int = 2) -> None:
-        env = SB3ActionMaskWrapper(env)
         env.reset()
         env = ActionMasker(env, lambda e: e.action_mask())
         check_env(env)

--- a/rl/env.py
+++ b/rl/env.py
@@ -35,6 +35,8 @@ class OPTCGPlayerObs:
     num_active_don_opponent: int
     num_life: int
     num_life_opponent: int
+    attack_power: int
+    attack_power_opponent: int
 
     def values(self):
         return {
@@ -57,6 +59,8 @@ class OPTCGPlayerObs:
             "num_active_don_opponent": int(self.num_active_don_opponent),
             "num_life": int(self.num_life),
             "num_life_opponent": int(self.num_life_opponent),
+            "attack_power": int(self.attack_power),
+            "attack_power_opponent": int(self.attack_power_opponent),
         }
 
 class OPTCGEnv(AECEnv):
@@ -127,6 +131,15 @@ class OPTCGEnv(AECEnv):
 
         agent_is_p1 = agent == "player_0"
 
+        raw_power_self = obs.attack_powers[1] if agent_is_p1 else obs.attack_powers[0]
+        raw_power_opp = obs.attack_powers[0] if agent_is_p1 else obs.attack_powers[1]
+
+        def scale_power(val: int) -> int:
+            return val if val == -1 else val // 1000
+
+        attack_power = scale_power(raw_power_self)
+        attack_power_opponent = scale_power(raw_power_opp)
+
         return OPTCGPlayerObs(
             can_attack=obs.can_attack,
             can_blocker=obs.can_blocker,
@@ -147,6 +160,8 @@ class OPTCGEnv(AECEnv):
             num_active_don_opponent=obs.num_active_don_p2 if agent_is_p1 else obs.num_active_don_p1,
             num_life=obs.num_life_p1 if agent_is_p1 else obs.num_life_p2,
             num_life_opponent=obs.num_life_p2 if agent_is_p1 else obs.num_life_p1,
+            attack_power=attack_power,
+            attack_power_opponent=attack_power_opponent,
         ).values()
 
     # ------------------------------------------------------------------

--- a/rl/env.py
+++ b/rl/env.py
@@ -72,6 +72,8 @@ class OPTCGEnv(AECEnv):
     }
     render_mode = None
     fake_obs = None
+    FAST_MODE = True
+    VERBOSE = True
 
     @staticmethod
     def _build_obs_space() -> spaces.Dict:
@@ -103,7 +105,7 @@ class OPTCGEnv(AECEnv):
         obs_space = self._build_obs_space()
         self.observation_spaces = {agent: obs_space for agent in self.possible_agents}
 
-    def observe(self, agent: str, fast_mode = True) -> Any:
+    def observe(self, agent: str) -> Any:
         def process_card_names(cards: List[str]) -> list:
             card_ids = []
             for card in cards:
@@ -111,7 +113,7 @@ class OPTCGEnv(AECEnv):
                 card_ids.append(card_id)
             return card_ids
 
-        if fast_mode and self.fake_obs:
+        if self.FAST_MODE and self.fake_obs:
             obs = copy(self.fake_obs)
         else:
             proceed = False
@@ -187,10 +189,10 @@ class OPTCGEnv(AECEnv):
     def action_mask(self, agent: str | None = None) -> list[int]:
         if agent is None:
             agent = self.agent_selection
-        n = self.action_spaces[agent].n
+        n = self.action_spaces[agent].__getattribute__("n")
         return [1] * n
 
-    def step(self, action: int, debug: bool = False) -> None:
+    def step(self, action: int) -> None:
         """Execute *action* and update environment state."""
         if self.terminations[self.agent_selection] or self.truncations[self.agent_selection]:
             self._was_dead_step(action)
@@ -220,9 +222,9 @@ class OPTCGEnv(AECEnv):
             self.terminations["player_0"] = True
             self.terminations["player_1"] = True
 
-        if debug:
+        if self.VERBOSE:
             print(f"--- ACTION: {action}")
-            print(f"--- OBS: {self._last_obs['player_0']}")
+            print(f"--- OBS: {self._last_obs[self.agent_selection]}")
 
         self._accumulate_rewards()
 

--- a/rl/env.py
+++ b/rl/env.py
@@ -3,16 +3,16 @@ from __future__ import annotations
 
 from copy import copy
 from dataclasses import asdict, dataclass, fields
-import time
-from typing import Any, List, get_args, get_origin
+from typing import Any, List
 
 import numpy as np
 from pettingzoo.utils.env import AECEnv
 from gymnasium import spaces
 
-from utils.gui import gui_macros as MACROS
+import gymnasium as gym
 from utils.gui import gui_automation_starter as GUI
 from utils.vision import finder
+
 
 @dataclass
 class OPTCGPlayerObs:
@@ -63,7 +63,8 @@ class OPTCGPlayerObs:
             "attack_power_opponent": int(self.attack_power_opponent),
         }
 
-class OPTCGEnv(AECEnv):
+
+class OPTCGEnvBase(AECEnv):
     """Minimal OPTCGSim environment following the PettingZoo AEC API."""
 
     metadata = {
@@ -73,7 +74,9 @@ class OPTCGEnv(AECEnv):
     render_mode = None
     fake_obs = None
     FAST_MODE = True
-    VERBOSE = True
+    VERBOSE = False
+    P1 = "player_0"
+    P2 = "player_1"
 
     @staticmethod
     def _build_obs_space() -> spaces.Dict:
@@ -87,7 +90,20 @@ class OPTCGEnv(AECEnv):
             elif typ == "int":
                 space_mapping[name] = spaces.Discrete(11)
             elif "List" in str(typ):
-                space_mapping[name] = spaces.Box(shape=(5 if "board" in name or "choice_cards" in name or "rested_cards" in name else 10,), low=0, high=13000, dtype=np.int64)
+                space_mapping[name] = spaces.Box(
+                    shape=(
+                        (
+                            5
+                            if "board" in name
+                            or "choice_cards" in name
+                            or "rested_cards" in name
+                            else 10
+                        ),
+                    ),
+                    low=0,
+                    high=13000,
+                    dtype=np.int64,
+                )
         return spaces.Dict(space_mapping)
 
     def __init__(self, max_steps: int = 100, step_delay: float = 0.5) -> None:
@@ -101,7 +117,9 @@ class OPTCGEnv(AECEnv):
         self.possible_agents = ["player_0", "player_1"]
         self.agents: List[str] = []
 
-        self.action_spaces = {agent: spaces.Discrete(25) for agent in self.possible_agents}
+        self.action_spaces = {
+            agent: spaces.Discrete(25) for agent in self.possible_agents
+        }
         obs_space = self._build_obs_space()
         self.observation_spaces = {agent: obs_space for agent in self.possible_agents}
 
@@ -109,7 +127,7 @@ class OPTCGEnv(AECEnv):
         def process_card_names(cards: List[str]) -> list:
             card_ids = []
             for card in cards:
-                card_id = int(card[2:].replace('-', '')) if card != '' else 0
+                card_id = int(card[2:].replace("-", "")) if card != "" else 0
                 card_ids.append(card_id)
             return card_ids
 
@@ -157,9 +175,15 @@ class OPTCGEnv(AECEnv):
             board=obs.board_p1 if agent_is_p1 else obs.board_p2,
             board_opponent=obs.board_p2 if agent_is_p1 else obs.board_p1,
             rested_cards=obs.rested_cards_p1 if agent_is_p1 else obs.rested_cards_p2,
-            rested_cards_opponent=obs.rested_cards_p2 if agent_is_p1 else obs.rested_cards_p1,
-            num_active_don=obs.num_active_don_p1 if agent_is_p1 else obs.num_active_don_p2,
-            num_active_don_opponent=obs.num_active_don_p2 if agent_is_p1 else obs.num_active_don_p1,
+            rested_cards_opponent=(
+                obs.rested_cards_p2 if agent_is_p1 else obs.rested_cards_p1
+            ),
+            num_active_don=(
+                obs.num_active_don_p1 if agent_is_p1 else obs.num_active_don_p2
+            ),
+            num_active_don_opponent=(
+                obs.num_active_don_p2 if agent_is_p1 else obs.num_active_don_p1
+            ),
             num_life=obs.num_life_p1 if agent_is_p1 else obs.num_life_p2,
             num_life_opponent=obs.num_life_p2 if agent_is_p1 else obs.num_life_p1,
             attack_power=attack_power,
@@ -169,7 +193,9 @@ class OPTCGEnv(AECEnv):
     # ------------------------------------------------------------------
     # Core API
     # ------------------------------------------------------------------
-    def reset(self, *, seed: int | None = None, options: dict[str, Any] | None = None) -> None:
+    def reset(
+        self, *, seed: int | None = None, options: dict[str, Any] | None = None
+    ) -> None:
         self.agents = self.possible_agents[:]
         self.terminations = {agent: False for agent in self.agents}
         self.truncations = {agent: False for agent in self.agents}
@@ -194,7 +220,10 @@ class OPTCGEnv(AECEnv):
 
     def step(self, action: int) -> None:
         """Execute *action* and update environment state."""
-        if self.terminations[self.agent_selection] or self.truncations[self.agent_selection]:
+        if (
+            self.terminations[self.agent_selection]
+            or self.truncations[self.agent_selection]
+        ):
             self._was_dead_step(action)
             return
 
@@ -240,22 +269,50 @@ class OPTCGEnv(AECEnv):
         )
 
 
+class OPTCGEnv(OPTCGEnvBase, gym.Env):
+    """Wrapper to adapt PettingZoo AEC environments for SB3 with action masking."""
+
+    def reset(self, seed: int | None = None, options: dict[str, Any] | None = None):
+        super().reset(seed=seed, options=options)
+        self.observation_space = super().observation_space(self.possible_agents[0])
+        self.action_space = super().action_space(self.possible_agents[0])
+        return self.observe(self.agent_selection), {}
+
+    def step(self, action: int):
+        current_agent = self.agent_selection
+        super().step(action)
+        next_agent = self.agent_selection
+        return (
+            self.observe(next_agent),
+            self.rewards[current_agent],
+            self.terminations[current_agent],
+            self.truncations[current_agent],
+            self.infos[current_agent],
+        )
+
+    def observe(self, agent: str):
+        obs = super().observe(agent)
+        if isinstance(obs, OPTCGPlayerObs):
+            return asdict(obs)
+        return obs
+
+    def action_mask(self):
+        return super().action_mask(self.agent_selection)
+
+
 def main(num_steps: int = 10) -> None:
     """Run a short random rollout for quick manual testing."""
     env = OPTCGEnv(max_steps=num_steps)
     env.reset()
 
-    obs, _, terminated, truncated, _ = env.last()
+    obs = env.observe(env.P1)
     print("reset ->", obs)
 
     # Player 1 takes five actions
     for i in range(5):
         action = env.action_spaces[env.agent_selection].sample()
-        env.step(action)
-        obs, reward, terminated, truncated, _ = env.last()
-        print(
-            f"p1 step {i}: a={action} r={reward} term={terminated} trunc={truncated}"
-        )
+        obs, reward, terminated, truncated, _ = env.step(action)
+        print(f"p1 step {i}: a={action} r={reward} term={terminated} trunc={truncated}")
         if terminated or truncated:
             print("final obs ->", obs)
             return
@@ -264,11 +321,8 @@ def main(num_steps: int = 10) -> None:
     env.switch_player()
     for i in range(4):
         action = env.action_spaces[env.agent_selection].sample()
-        env.step(action)
-        obs, reward, terminated, truncated, _ = env.last()
-        print(
-            f"p2 step {i}: a={action} r={reward} term={terminated} trunc={truncated}"
-        )
+        obs, reward, terminated, truncated, _ = env.step(action)
+        print(f"p2 step {i}: a={action} r={reward} term={terminated} trunc={truncated}")
         if terminated or truncated:
             print("final obs ->", obs)
             return
@@ -276,11 +330,8 @@ def main(num_steps: int = 10) -> None:
     # Switch back to Player 1 for a final action
     env.switch_player()
     action = env.action_spaces[env.agent_selection].sample()
-    env.step(action)
-    obs, reward, terminated, truncated, _ = env.last()
-    print(
-        f"p1 step 5: a={action} r={reward} term={terminated} trunc={truncated}"
-    )
+    obs, reward, terminated, truncated, _ = env.step(action)
+    print(f"p1 step 5: a={action} r={reward} term={terminated} trunc={truncated}")
     print("final obs ->", obs)
 
 

--- a/tensorboard_start.bat
+++ b/tensorboard_start.bat
@@ -1,0 +1,17 @@
+@echo off
+REM Set the directory where SB3 writes logs
+set LOGDIR="./logs/"
+if "%LOGDIR%"=="" (
+    echo Usage: run_tensorboard.bat path\to\logdir [port]
+    pause
+    goto :eof
+)
+REM Optional second argument: port number
+set PORT=%~2
+if "%PORT%"=="" set PORT=6006
+
+echo Starting TensorBoard...
+tensorboard --logdir="%LOGDIR%" --port=%PORT%
+REM Optional: open browser automatically
+start http://localhost:%PORT%
+pause

--- a/utils/vision/finder.py
+++ b/utils/vision/finder.py
@@ -371,6 +371,7 @@ class OPTCGVision:
                 x1 = int(x0 + SLOT_WIDTH_PCT * w)
                 roi = frame[y0:y1, x0:x1]
                 cards.append(self._detect_card_in_roi(roi, hand=True))
+            assert len(cards) <= HAND_MAX_SIZE
             cards += [''] * (HAND_MAX_SIZE - len(cards))
             return cards
 


### PR DESCRIPTION
## Summary
- extend `OPTCGPlayerObs` with `attack_power` and `attack_power_opponent`
- convert `attack_powers` from `OPTCGObs` when observing

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68853da12d3c833096cf5370876d86a1