### PR TITLE
Add leader rested detection

### DIFF
--- a/rl/env.py
+++ b/rl/env.py
@@ -31,6 +31,8 @@ class OPTCGPlayerObs:
     board_opponent: List[str]
     rested_cards: List[int]
     rested_cards_opponent: List[int]
+    leader_rested: bool
+    leader_rested_opponent: bool
     num_active_don: int
     num_active_don_opponent: int
     num_life: int
@@ -55,6 +57,8 @@ class OPTCGPlayerObs:
             "board_opponent": np.array(self.board_opponent),
             "rested_cards": np.array(self.rested_cards),
             "rested_cards_opponent": np.array(self.rested_cards_opponent),
+            "leader_rested": int(self.leader_rested),
+            "leader_rested_opponent": int(self.leader_rested_opponent),
             "num_active_don": int(self.num_active_don),
             "num_active_don_opponent": int(self.num_active_don_opponent),
             "num_life": int(self.num_life),
@@ -196,6 +200,12 @@ class OPTCGEnvBase(AECEnv):
             rested_cards=obs.rested_cards_p1 if agent_is_p1 else obs.rested_cards_p2,
             rested_cards_opponent=(
                 obs.rested_cards_p2 if agent_is_p1 else obs.rested_cards_p1
+            ),
+            leader_rested=(
+                obs.leader_rested_p1 if agent_is_p1 else obs.leader_rested_p2
+            ),
+            leader_rested_opponent=(
+                obs.leader_rested_p2 if agent_is_p1 else obs.leader_rested_p1
             ),
             num_active_don=(
                 obs.num_active_don_p1 if agent_is_p1 else obs.num_active_don_p2

--- a/utils/vision/finder.py
+++ b/utils/vision/finder.py
@@ -311,6 +311,10 @@ class OPTCGVision:
         DON_P1_START_X, DON_P1_END_X, DON_P1_Y = 0.35, 0.6, 0.90
         DON_P2_START_X, DON_P2_END_X, DON_P2_Y = 0.65, 0.4, 0.15
         DON_HEIGHT_PCT = 0.20
+        LEADER_P1_X = 0.48
+        LEADER_P1_Y = BOARD_P1_Y
+        LEADER_P2_X = 0.43
+        LEADER_P2_Y = DON_P2_Y
         LIFE_P1_X0_PCT, LIFE_P1_Y0_PCT, LIFE_P1_X1_PCT, LIFE_P1_Y1_PCT = (
             0.30,
             0.55,
@@ -459,8 +463,8 @@ class OPTCGVision:
             DON_P2_START_X, DON_P2_END_X, DON_P2_Y, "DON_side_p2"
         )
 
-        leader_rested_p1 = scan_leader(0.45, BOARD_P1_Y + BOARD_HEIGHT_PCT)
-        leader_rested_p2 = scan_leader(0.35, DON_P2_Y + DON_HEIGHT_PCT)
+        leader_rested_p1 = scan_leader(LEADER_P1_X, LEADER_P1_Y)
+        leader_rested_p2 = scan_leader(LEADER_P2_X, LEADER_P2_Y)
 
         # 5. Choice row ------------------------------------------------------
         choice_cards: List[str] = ["", "", "", "", ""]

--- a/utils/vision/finder.py
+++ b/utils/vision/finder.py
@@ -141,6 +141,8 @@ class OPTCGObs:
     board_p2: List[str]
     rested_cards_p1: List[int]
     rested_cards_p2: List[int]
+    leader_rested_p1: bool
+    leader_rested_p2: bool
     num_active_don_p1: int
     num_active_don_p2: int
     num_life_p1: int
@@ -414,6 +416,16 @@ class OPTCGVision:
             hits = self.find(template, frame=roi, is_card=True)
             return min(len(hits), 10)
 
+        def scan_leader(start_x: float, start_y: float) -> bool:
+            """Return True if the leader in the region is rested."""
+            y0 = int(start_y * h)
+            y1 = int(min(start_y + BOARD_HEIGHT_PCT, 1.0) * h)
+            x0 = int(start_x * w)
+            x1 = int((start_x + BOARD_WIDTH_PCT) * w)
+            roi = frame[y0:y1, x0:x1]
+            _, rested = self._detect_card_and_rest(roi)
+            return rested
+
         # 3. Player-1 --------------------------------------------------------
         p1_y0, p1_y1 = int(0.80 * h), h
         p1_count = count_hand_cards(p1_y0, p1_y1)
@@ -446,6 +458,9 @@ class OPTCGVision:
         num_active_don_p2 = scan_don(
             DON_P2_START_X, DON_P2_END_X, DON_P2_Y, "DON_side_p2"
         )
+
+        leader_rested_p1 = scan_leader(0.45, BOARD_P1_Y + BOARD_HEIGHT_PCT)
+        leader_rested_p2 = scan_leader(0.35, DON_P2_Y + DON_HEIGHT_PCT)
 
         # 5. Choice row ------------------------------------------------------
         choice_cards: List[str] = ["", "", "", "", ""]
@@ -483,6 +498,8 @@ class OPTCGVision:
             board_p2 = board_p2,
             rested_cards_p1 = rested_p1,
             rested_cards_p2 = rested_p2,
+            leader_rested_p1 = leader_rested_p1,
+            leader_rested_p2 = leader_rested_p2,
             num_active_don_p1 = num_active_don_p1,
             num_active_don_p2 = num_active_don_p2,
             num_life_p1 = num_life_p1,


### PR DESCRIPTION
## Summary
- track whether leaders are rested for each player
- expose rested leader flags in `OPTCGPlayerObs`
- scan leader regions in vision system

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6886a587e7f88330ac87a065055ce445