### PR TITLE
Integrate RL Baselines3 Zoo

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pettingzoo>=1.24,<2.0
 stable-baselines3>=2.7,<3.0
 supersuit>=3.10,<4.0
 sb3-contrib>=2.0,<3.0
+rl_zoo3>=2.2,<3.0

--- a/rl/train_agent.py
+++ b/rl/train_agent.py
@@ -1,0 +1,30 @@
+"""Train and tune the OPTCG agent using RL Baselines3 Zoo.
+
+This script registers the custom :class:`~rl.env.OPTCGEnv` environment and
+extends the Zoo so that ``MaskablePPO`` can be used. It then delegates to
+:func:`rl_zoo3.train.train`, so any CLI options supported by RL Baselines3 Zoo
+are available.
+"""
+
+from gymnasium.envs.registration import register
+
+# Register the environment with Gymnasium when this module is imported.
+register(id="OPTCG-v0", entry_point="rl.env:OPTCGEnv")
+
+from sb3_contrib import MaskablePPO
+import rl_zoo3.utils as zoo_utils
+import rl_zoo3.hyperparams_opt as hpo
+from rl_zoo3.train import train
+
+# Make MaskablePPO available in the Zoo CLI
+zoo_utils.ALGOS["maskableppo"] = MaskablePPO
+hpo.HYPERPARAMS_SAMPLER["maskableppo"] = hpo.sample_ppo_params
+
+
+def main() -> None:
+    """Launch the training process using RL Baselines3 Zoo."""
+    train()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()


### PR DESCRIPTION
## Summary
- add RL Baselines3 Zoo as a dependency
- add `train_agent.py` that uses RL Zoo's training utilities

## Testing
- `python -m py_compile rl/train_agent.py`

------
https://chatgpt.com/codex/tasks/task_e_688a90d1fa488330a0d469c44bca144d